### PR TITLE
Strow

### DIFF
--- a/emis/emis_danz.m
+++ b/emis/emis_danz.m
@@ -4,7 +4,7 @@ function [emis] = emis_danz(lat,lon,rtime,efreq);
 % Returns Dan Zhou's land emissivity climatology
 % Dan provides a monthly climatology, here we do both
 % temporal and spatial linear interpolation.
-
+addpath /asl/packages/time
 % danz interpolant is big, keep it around
 persistent danz
 if isempty(danz)
@@ -19,8 +19,10 @@ load /asl/data/iremis/danz/u_vector_global
 newc = zeros(10,nobs);
 
 % Now figure out numerical months
-mtime = datetime(1993,1,1,0,0,rtime);
-mon = double(day(mtime,'dayofyear')/365);
+mtime = tai2dtime(rtime);
+
+mon = single(day(mtime,'dayofyear')/365);
+
 % Find interpolated expansion coefficients (linear is default)
 for i=1:10
     newc(i,:) = danz(i).emis(lon,lat,mon);

--- a/emis/rtp_add_emis.m
+++ b/emis/rtp_add_emis.m
@@ -41,6 +41,7 @@ efreq = fiasi(efreqi);
 % Only ask emis_danz for land emissivities, any fraction
 kland     = find( prof.landfrac > 0 );
 emis_land = emis_danz(prof.rlat(kland),prof.rlon(kland),prof.rtime(kland),efreq);
+
 % Get sea emissivities, only for pure water scene
 kwater    = find( prof.landfrac <= 0);
 [sea_nemis, sea_efreq, sea_emis] = emis_sea(prof.satzen(kwater), prof.wspeed(kwater));

--- a/grib/fill_ecmwf.m
+++ b/grib/fill_ecmwf.m
@@ -13,8 +13,7 @@ fhdr = '/asl/data/ecmwf_nc/';
 
 ename = '';  % This should be placed outside a rtp file loop
 
-ntime = datetime(1958,1,1,0,0,prof.rtime);
-mtime = datenum(ntime);
+mtime = tai2dnum(prof.rtime);
 
 % Get a cell array of ecmwf grib files for each time
 % I think this will be BROKEN if using datetime above!!

--- a/grib/fill_ecmwf.m
+++ b/grib/fill_ecmwf.m
@@ -7,6 +7,7 @@
 function [prof, head] = fill_ecmwf(prof, head);
 
 addpath /asl/matlib/aslutil
+addpath /asl/packages/time
 
 % Location of grib files
 fhdr = '/asl/data/ecmwf_nc/';

--- a/grib/fill_era.m
+++ b/grib/fill_era.m
@@ -7,12 +7,13 @@
 function [prof, head] = fill_era(prof, head)
 
 addpath /asl/matlib/aslutil
+addpath /asl/packages/time
 
 % Location of grib files
 fhdr = '/asl/data/era/';
 
 ename = '';  % This should be placed outside a rtp file loop
-mtime = datenum(1958,1,1,0,0,prof.rtime);
+mtime = tai2dnum(prof.rtime);
 
 % Get a cell array of era grib files for each time
 % Round to get 4 forecast hours per day


### PR DESCRIPTION
These are some old changes I never pushed to github.   I used my posting on how to do git rebasing for this work and it did the trick (I hope).

These change require that /asl/packages/time exists, it is now pointing to /home/motteler/cris/ccast/motmsc/time.   

Note that I used datetime format internally in emis_danz, but it is not passed out.  fill_ecmwf just switches from an almost correct version of datenum to Howard's correct version using tai2dnum.m
